### PR TITLE
Added logic to perists SDS definitions to central store

### DIFF
--- a/etc/tendrl/tendrl.conf.sample
+++ b/etc/tendrl/tendrl.conf.sample
@@ -15,3 +15,4 @@ log_level = DEBUG
 # Path to log file
 log_level = DEBUG
 log_cfg_path = /etc/tendrl/logging.yaml
+sds_definitions_path = /etc/tendrl/tendrl_definitions_gluster-3.8.3.yaml

--- a/tendrl/gluster_bridge/persistence/sds_operation.py
+++ b/tendrl/gluster_bridge/persistence/sds_operation.py
@@ -1,0 +1,19 @@
+from tendrl.bridge_common.etcdobj.etcdobj import EtcdObj
+from tendrl.bridge_common.etcdobj import fields
+
+
+class SDSOperation(EtcdObj):
+    """A table for storing SDS operations definitions YAML
+
+    """
+    __name__ = 'clusters/%s/definitions'
+
+    cluster_id = fields.StrField("cluster_id")
+    # Here the data represents the whole content of SDS definitions YAML file
+    # The same is uploaded to central store for easy access while other flows
+    data = fields.StrField("data")
+    updated = fields.StrField("updated")
+
+    def render(self):
+        self.__name__ = self.__name__ % self.cluster_id
+        return super(SDSOperation, self).render()

--- a/tendrl/gluster_bridge/tests/test_gluster_bridge.py
+++ b/tendrl/gluster_bridge/tests/test_gluster_bridge.py
@@ -9,8 +9,10 @@ import os
 import shutil
 import sys
 import tempfile
+sys.modules['tendrl.bridge_common.JobValidator'] = MagicMock()
 sys.modules['tendrl.bridge_common'] = MagicMock()
 sys.modules['tendrl.gluster_bridge.persistence.servers'] = MagicMock()
+sys.modules['tendrl.gluster_bridge.persistence.sds_operation'] = MagicMock()
 sys.modules['tendrl.gluster_bridge.config'] = MagicMock()
 sys.modules['tendrl.gluster_bridge.manager.rpc'] = MagicMock()
 sys.modules['tendrl.gluster_bridge.persistence.persister'] = MagicMock()
@@ -22,6 +24,8 @@ del sys.modules['logging']
 del sys.modules['tendrl.gluster_bridge.config']
 del sys.modules['tendrl.bridge_common']
 del sys.modules['tendrl.gluster_bridge.persistence.servers']
+del sys.modules['tendrl.gluster_bridge.persistence.sds_operation']
+del sys.modules['tendrl.bridge_common.JobValidator']
 
 
 class TestGluster_bridge(object):

--- a/tendrl/gluster_bridge/tests/test_manager.py
+++ b/tendrl/gluster_bridge/tests/test_manager.py
@@ -83,6 +83,7 @@ class Test_manager(TestGluster_bridge):
         self.Manager.LOG.debug.assert_called()
 
     def test_start(self):
+        self.managerobj.initialize_sds_definitions = MagicMock()
         self.managerobj.start()
         self.managerobj._user_request_thread.start.assert_called()
         self.managerobj.persister.start.assert_called()
@@ -97,11 +98,6 @@ class Test_manager(TestGluster_bridge):
     def test_dump_stacks(self):
         self.Manager.dump_stacks()
         self.Manager.LOG.errorassert_called()
-
-    def test_main(self):
-        self.Manager.gevent = MagicMock()
-        self.Manager.main()
-        self.Manager.gevent.signal.assert_called()
 
     """Mocked subprocess call to stop while loop"""
     def call(self, *args):


### PR DESCRIPTION
While starting of the bridge, the SDS definitions is loaded
and added to central store in path /cluster/<cluster-id>/definitions

Signed-off-by: Shubhendu <shtripat@redhat.com>