### PR TITLE
Update tendrl-glusterd.service

### DIFF
--- a/tendrl-glusterd.service
+++ b/tendrl-glusterd.service
@@ -7,7 +7,7 @@ ExecStart=/usr/bin/tendrl-gluster-integration
 ExecReload=/bin/kill -HUP $MAINPID
 KillMode=process
 Restart=on-failure
-PrivateTmp=true
+PrivateTmp=false
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
With PrivateTmp set as true, a new /tmp is created and isolated from the other one. All the data saved inside are deleted once the service is stopped.

This was causing read failure while reading data from /tmp/glusterd-state in gluster-inetgration service while is written by glusterd command.