### PR TITLE
Update manager.py

### DIFF
--- a/tendrl/gluster_integration/manager/manager.py
+++ b/tendrl/gluster_integration/manager/manager.py
@@ -59,13 +59,13 @@ class TopLevelEvents(gevent.greenlet.Greenlet):
                         'get-state',
                         'glusterd',
                         'odir',
-                        '/tmp',
+                        '/var/run',
                         'file',
                         'glusterd-state'
                     ]
                 )
-                raw_data = ini2json.ini_to_dict('/tmp/glusterd-state')
-                subprocess.call(['rm', '-rf', '/tmp/glusterd-state'])
+                raw_data = ini2json.ini_to_dict('/var/run/glusterd-state')
+                subprocess.call(['rm', '-rf', '/var/run/glusterd-state'])
                 self._manager.on_pull(raw_data, self.cluster_id)
             except Exception as ex:
                 LOG.error(ex)


### PR DESCRIPTION
Each systemctl service gets its own /tmp variation and owns that. If we use /tmp for creating glusterd-state file, tendrl-glusterd service is not able to read from the same as the file is written by glusterd service.

Changed the path to write the file to /var/run rather and this solves the issue.