### PR TITLE
Logged EtcdKeyNotFound exception from rpc.py

### DIFF
--- a/tendrl/gluster_integration/manager/rpc.py
+++ b/tendrl/gluster_integration/manager/rpc.py
@@ -159,6 +159,9 @@ class EtcdThread(gevent.greenlet.Greenlet):
             try:
                 LOG.info("%s run..." % self.__class__.__name__)
                 self._server.run()
+            except etcd.EtcdKeyNotFound as ex:
+                LOG.debug("Given key is not present in etcd . %s", ex)
+                self._complete.wait(self.EXCEPTION_BACKOFF)
             except Exception:
                 LOG.error(traceback.format_exc())
                 self._complete.wait(self.EXCEPTION_BACKOFF)

--- a/tendrl/gluster_integration/tests/test_rpc.py
+++ b/tendrl/gluster_integration/tests/test_rpc.py
@@ -96,6 +96,15 @@ class TestEtcdThread(object):
         self.etcdthread._run()
         assert self.raw_job['status'] == 'failed'
 
+    def test_etcdthread_error(self, monkeypatch):
+        def Mock_read(param):
+            if param == '/queue':
+                raise rpc.etcd.EtcdKeyNotFound
+        monkeypatch.setattr(
+            self.etcdthread._server.client, "read", Mock_read)
+        self.etcdthread._run()
+        assert True
+
     def test_stop(self):
         self.etcdthread._complete.set = MagicMock()
         self.etcdthread.stop()


### PR DESCRIPTION
Instead of the exception, EtcdKeyNotFound is logged successfully
tendrl-bug-id:Tendrl/gluster_integration#26

Signed-off-by: root <gshanmug@redhat.com>