### PR TITLE
Added logic to populate volume options to central store

### DIFF
--- a/tendrl/gluster_integration/manager/manager.py
+++ b/tendrl/gluster_integration/manager/manager.py
@@ -237,7 +237,7 @@ class GlusterIntegrationManager(Manager):
                 except KeyError:
                     break
             # poplate the volume options
-            reg_ex = re.compile("^volume[0-9].options+")
+            reg_ex = re.compile("^volume[0-9]+.options+")
             options = {}
             for key in volumes.keys():
                 if reg_ex.match(key):

--- a/tendrl/gluster_integration/manager/manager.py
+++ b/tendrl/gluster_integration/manager/manager.py
@@ -1,6 +1,7 @@
 import gevent.event
 import json
 import logging
+import re
 import signal
 import subprocess
 import sys
@@ -20,6 +21,8 @@ from tendrl.gluster_integration.persistence.persister \
 from tendrl.gluster_integration.persistence.servers import Brick
 from tendrl.gluster_integration.persistence.servers import Peer
 from tendrl.gluster_integration.persistence.servers import Volume
+from tendrl.gluster_integration.persistence.servers import VolumeOptions
+
 from tendrl.gluster_integration.persistence.tendrl_context import TendrlContext
 from tendrl.gluster_integration.persistence.tendrl_definitions import \
     TendrlDefinitions
@@ -118,15 +121,79 @@ class GlusterIntegrationManager(Manager):
                     self.persister_thread.update_volume(
                         Volume(
                             cluster_id=cluster_id,
-                            vol_id=volumes['volume%s.id' % index],
-                            vol_type=volumes['volume%s.type' % index],
-                            name=volumes['volume%s.name' % index],
-                            status=volumes['volume%s.status' % index],
-                            brick_count=volumes['volume%s.brickcount' % index])
+                            vol_id=volumes[
+                                'volume%s.id' % index
+                            ],
+                            vol_type=volumes[
+                                'volume%s.type' % index
+                            ],
+                            name=volumes[
+                                'volume%s.name' % index
+                            ],
+                            transport_type=volumes[
+                                'volume%s.transport_type' % index
+                            ],
+                            status=volumes[
+                                'volume%s.status' % index
+                            ],
+                            brick_count=volumes[
+                                'volume%s.brickcount' % index
+                            ],
+                            snap_count=volumes[
+                                'volume%s.snap_count' % index
+                            ],
+                            stripe_count=volumes[
+                                'volume%s.stripe_count' % index
+                            ],
+                            replica_count=volumes[
+                                'volume%s.replica_count' % index
+                            ],
+                            subvol_count=volumes[
+                                'volume%s.subvol_count' % index
+                            ],
+                            arbiter_count=volumes[
+                                'volume%s.arbiter_count' % index
+                            ],
+                            disperse_count=volumes[
+                                'volume%s.disperse_count' % index
+                            ],
+                            redundancy_count=volumes[
+                                'volume%s.redundancy_count' % index
+                            ],
+                            quorum_status=volumes[
+                                'volume%s.quorum_status' % index
+                            ],
+                            snapd_status=volumes[
+                                'volume%s.snapd_svc.online_status' % index
+                            ],
+                            snapd_inited=volumes[
+                                'volume%s.snapd_svc.inited' % index
+                            ],
+                            rebal_id=volumes[
+                                'volume%s.rebalance.id' % index
+                            ],
+                            rebal_status=volumes[
+                                'volume%s.rebalance.status' % index
+                            ],
+                            rebal_failures=volumes[
+                                'volume%s.rebalance.failures' % index
+                            ],
+                            rebal_skipped=volumes[
+                                'volume%s.rebalance.skipped' % index
+                            ],
+                            rebal_lookedup=volumes[
+                                'volume%s.rebalance.lookedup' % index
+                            ],
+                            rebal_files=volumes[
+                                'volume%s.rebalance.files' % index
+                            ],
+                            rebal_data=volumes[
+                                'volume%s.rebalance.data' % index
+                            ],
+                        )
                     )
                     LOG.info("on_pull, Updating Volume %s" %
                              volumes['volume%s.id' % index])
-
                     b_index = 1
                     # populate brick data for this volume
                     while True:
@@ -169,6 +236,27 @@ class GlusterIntegrationManager(Manager):
                     index += 1
                 except KeyError:
                     break
+            # poplate the volume options
+            reg_ex = re.compile("^volume[0-9].options+")
+            options = {}
+            for key in volumes.keys():
+                if reg_ex.match(key):
+                    options[key] = volumes[key]
+            for key in options.keys():
+                volname = key.split('.')[0]
+                vol_id = volumes['%s.id' % volname]
+                dict = {}
+                for k, v in options.items():
+                    if k.startswith('%s.options' % volname):
+                        dict['.'.join(k.split(".")[2:])] = v
+                        options.pop(k, None)
+                self.persister.update_volume_options(
+                    VolumeOptions(
+                        cluster_id=cluster_id,
+                        vol_id=vol_id,
+                        Options=dict
+                    )
+                )
 
     def register_to_cluster(self, cluster_id):
         self.persister_thread.update_tendrl_context(

--- a/tendrl/gluster_integration/manager/tendrl_definitions_gluster.py
+++ b/tendrl/gluster_integration/manager/tendrl_definitions_gluster.py
@@ -230,6 +230,57 @@ namespace.tendrl.gluster_integration:
         volname:
           help: "Name of gluster volume"
           type: String
+        vol_type:
+          help: "Type of the volume"
+          type: String
+        rebal_data:
+          help: "Rebalance data"
+          type: String
+        rebal_skipped:
+          help: "Skipped files while rebalance"
+          type: String
+        subvol_count:
+          help: "Count of subvolumes"
+          type: Integer
+        brick_count:
+          help: "Count of bricks"
+          type: Integer
+        cluster_id:
+          help: "UUID of the cluster"
+          type: String
+        snapd_inited:
+          help: "If snapd is initialized"
+          type: String
+        status:
+          help: "Status of the volume"
+          type: String
+        rebal_id:
+          help: "UUID of the rabalance task"
+          typoe: String
+        rebal_lookedup:
+          help: "Looked up files for rebalance"
+          type: Integer
+        snap_count:
+          help: "Count of the snapshots"
+          type: Integer
+        rebal_files:
+          help: "No of files rebalanced"
+          type: Integer
+        snapd_status:
+          help: "Status of snapd"
+          type: String
+        options:
+          help: "options list for volume"
+          type: json
+        quorum_status:
+          help: "Quorum status"
+          type: String
+        rebal_status:
+          help: "Status of rebalance task"
+          type: String
+        rebal_failures:
+          help: "Failed no of files for rebalance"
+          type: Integer
       enabled: true
       value: clusters/$Tendrl_context.cluster_id/Volumes/$Volume.vol_id/
 tendrl_schema_version: 0.3

--- a/tendrl/gluster_integration/persistence/servers.py
+++ b/tendrl/gluster_integration/persistence/servers.py
@@ -32,6 +32,24 @@ class Volume(EtcdObj):
     status = fields.StrField("status")
     brick_count = fields.StrField("brick_count")
     deleted = fields.StrField("deleted")
+    transport_type = fields.StrField("transport_type")
+    snap_count = fields.IntField("snap_count")
+    stripe_count = fields.IntField("stripe_count")
+    replica_count = fields.IntField("replica_count")
+    subvol_count = fields.IntField("subvol_count")
+    arbiter_count = fields.IntField("arbiter_count")
+    disperse_count = fields.IntField("disperse_count")
+    redundancy_count = fields.IntField("redundancy_count")
+    quorum_status = fields.StrField("quorum_status")
+    snapd_status = fields.StrField("snapd_status")
+    snapd_inited = fields.StrField("snapd_inited")
+    rebal_id = fields.StrField("rebal_id")
+    rebal_status = fields.StrField("rebal_status")
+    rebal_failures = fields.IntField("rebal_failures")
+    rebal_skipped = fields.IntField("rebal_skipped")
+    rebal_lookedup = fields.IntField("rebal_lookedup")
+    rebal_files = fields.IntField("rebal_files")
+    rebal_data = fields.StrField("rebal_data")
 
     def render(self):
         self.__name__ = self.__name__ % (self.cluster_id, self.vol_id)
@@ -60,3 +78,21 @@ class Brick(EtcdObj):
             self.path.replace("/", "_")
         )
         return super(Brick, self).render()
+
+
+class VolumeOptions(EtcdObj):
+    """A table of the volume options seen by the pull.
+
+    """
+    __name__ = 'clusters/%s/Volumes/%s'
+
+    cluster_id = fields.StrField("cluster_id")
+    vol_id = fields.StrField("vol_id")
+    Options = fields.DictField("Options", {'str': 'str'})
+
+    def render(self):
+        self.__name__ = self.__name__ % (
+            self.cluster_id,
+            self.vol_id
+        )
+        return super(VolumeOptions, self).render()

--- a/tendrl/gluster_integration/tests/test_manager.py
+++ b/tendrl/gluster_integration/tests/test_manager.py
@@ -28,20 +28,51 @@ class Test_manager(TestGluster_integration):
 
     def test_manager_with_volume(self):
         body = """[Global]\nop-version:40000 \
-        \n[Volumes]\nvolume1.id=1\nvolume1.type=abc" \
-        \nvolume1.name=brick1\nvolume1.status=active\nvolume1.brickcount=1"""
+        \n[Volumes]\nvolume1.id=1\nvolume1.type=abc \
+        \nvolume1.name=brick1\nvolume1.status=active\nvolume1.brickcount=1 \
+        \nvolume1.transport_type=tcp\nvolume1.snap_count=0 \
+        \nvolume1.stripe_count=1\nvolume1.replica_count=1 \
+        \nvolume1.subvol_count=1\nvolume1.arbiter_count=0 \
+        \nvolume1.disperse_count=0\nvolume1.redundancy_count=0 \
+        \nvolume1.quorum_status='not_applicable' \
+        \nvolume1.snapd_svc.online_status=Offline \
+        \nvolume1.snapd_svc.inited=True \
+        \nvolume1.rebalance.id=00000000-0000-0000-0000-000000000000 \
+        \nvolume1.rebalance.status=not_started \
+        \nvolume1.rebalance.failures=0\nvolume1.rebalance.skipped=0 \
+        \nvolume1.rebalance.lookedup=0\nvolume1.rebalance.files=0 \
+        \nvolume1.rebalance.data=0Bytes"""
         self.Initialize(body)
         self.managerobj._discovery_thread._run()
         self.Manager.Volume.assert_called_with(
-            brick_count='1', cluster_id=self.clusterid,
-            name='brick1', status='active',
-            vol_id='1', vol_type='abc"'
-            )
+            arbiter_count='0', brick_count='1',
+            cluster_id='e859cb15-2851-43d1-896c-1d9e845c0721',
+            disperse_count='0', name='brick1',
+            quorum_status="'not_applicable'", rebal_data='0Bytes',
+            rebal_failures='0', rebal_files='0',
+            rebal_id='00000000-0000-0000-0000-000000000000',
+            rebal_lookedup='0', rebal_skipped='0', rebal_status='not_started',
+            redundancy_count='0', replica_count='1', snap_count='0',
+            snapd_inited='True', snapd_status='Offline', status='active',
+            stripe_count='1', subvol_count='1', transport_type='tcp',
+            vol_id='1', vol_type='abc')
 
     def test_manager_with_brick(self):
         body = """[Global]\nop-version:40000 \
-        \n[Volumes]\nvolume1.id=1\nvolume1.type=abc" \
+        \n[Volumes]\nvolume1.id=1\nvolume1.type=abc \
         \nvolume1.name=brick1\nvolume1.status=active\nvolume1.brickcount=1 \
+        \nvolume1.transport_type=tcp\nvolume1.snap_count=0 \
+        \nvolume1.stripe_count=1\nvolume1.replica_count=1 \
+        \nvolume1.subvol_count=1\nvolume1.arbiter_count=0 \
+        \nvolume1.disperse_count=0\nvolume1.redundancy_count=0 \
+        \nvolume1.quorum_status='not_applicable' \
+        \nvolume1.snapd_svc.online_status=Offline \
+        \nvolume1.snapd_svc.inited=True \
+        \nvolume1.rebalance.id=00000000-0000-0000-0000-000000000000 \
+        \nvolume1.rebalance.status=not_started \
+        \nvolume1.rebalance.failures=0\nvolume1.rebalance.skipped=0 \
+        \nvolume1.rebalance.lookedup=0\nvolume1.rebalance.files=0 \
+        \nvolume1.rebalance.data=0Bytes \
         \nvolume1.brick1.path=/tmp\nvolume1.brick1.hostname=abc \
         \nvolume1.brick1.port=80\nvolume1.brick1.status=active \
         \nvolume1.brick1.filesystem_type=FAT12 \

--- a/tendrl/gluster_integration/tests/test_servers.py
+++ b/tendrl/gluster_integration/tests/test_servers.py
@@ -52,6 +52,14 @@ class Test_Volume(object):
         assert self.volume.render() == [
             {
                 'dir': False,
+                'name': 'arbiter_count',
+                'key': '/clusters/12345678-1234-5678-1234-567812345678/'
+                       'Volumes/12345678-1234-5678-1234-567812345678/'
+                       'arbiter_count',
+                'value': None
+            },
+            {
+                'dir': False,
                 'name': 'brick_count',
                 'key': '/clusters/12345678-1234-5678-1234-567812345678/'
                        'Volumes/12345678-1234-5678-1234-567812345678/'
@@ -76,6 +84,14 @@ class Test_Volume(object):
             },
             {
                 'dir': False,
+                'name': 'disperse_count',
+                'key': '/clusters/12345678-1234-5678-1234-567812345678/'
+                       'Volumes/12345678-1234-5678-1234-567812345678/'
+                       'disperse_count',
+                'value': None
+            },
+            {
+                'dir': False,
                 'name': 'name',
                 'key': '/clusters/12345678-1234-5678-1234-567812345678/'
                        'Volumes/12345678-1234-5678-1234-567812345678/'
@@ -84,11 +100,140 @@ class Test_Volume(object):
             },
             {
                 'dir': False,
+                'name': 'quorum_status',
+                'key': '/clusters/12345678-1234-5678-1234-567812345678/'
+                       'Volumes/12345678-1234-5678-1234-567812345678/'
+                       'quorum_status',
+                'value': None
+            },
+            {
+                'dir': False,
+                'name': 'rebal_data',
+                'key': '/clusters/12345678-1234-5678-1234-567812345678/'
+                       'Volumes/12345678-1234-5678-1234-567812345678/'
+                       'rebal_data',
+                'value': None
+            },
+            {
+                'dir': False,
+                'name': 'rebal_failures',
+                'key': '/clusters/12345678-1234-5678-1234-567812345678/'
+                       'Volumes/12345678-1234-5678-1234-567812345678/'
+                       'rebal_failures',
+                'value': None
+            },
+            {
+                'dir': False,
+                'name': 'rebal_files',
+                'key': '/clusters/12345678-1234-5678-1234-567812345678/'
+                       'Volumes/12345678-1234-5678-1234-567812345678/'
+                       'rebal_files',
+                'value': None
+            },
+            {
+                'dir': False,
+                'name': 'rebal_id',
+                'key': '/clusters/12345678-1234-5678-1234-567812345678/'
+                       'Volumes/12345678-1234-5678-1234-567812345678/'
+                       'rebal_id',
+                'value': None
+            },
+            {
+                'dir': False,
+                'name': 'rebal_lookedup',
+                'key': '/clusters/12345678-1234-5678-1234-567812345678/'
+                       'Volumes/12345678-1234-5678-1234-567812345678/'
+                       'rebal_lookedup',
+                'value': None
+            },
+            {
+                'dir': False,
+                'name': 'rebal_skipped',
+                'key': '/clusters/12345678-1234-5678-1234-567812345678/'
+                       'Volumes/12345678-1234-5678-1234-567812345678/'
+                       'rebal_skipped',
+                'value': None
+            },
+            {
+                'dir': False,
+                'name': 'rebal_status',
+                'key': '/clusters/12345678-1234-5678-1234-567812345678/'
+                       'Volumes/12345678-1234-5678-1234-567812345678/'
+                       'rebal_status',
+                'value': None
+            },
+            {
+                'dir': False,
+                'name': 'redundancy_count',
+                'key': '/clusters/12345678-1234-5678-1234-567812345678/'
+                       'Volumes/12345678-1234-5678-1234-567812345678/'
+                       'redundancy_count',
+                'value': None
+            },
+            {
+                'dir': False,
+                'name': 'replica_count',
+                'key': '/clusters/12345678-1234-5678-1234-567812345678/'
+                       'Volumes/12345678-1234-5678-1234-567812345678/'
+                       'replica_count',
+                'value': None
+            },
+            {
+                'dir': False,
+                'name': 'snap_count',
+                'key': '/clusters/12345678-1234-5678-1234-567812345678/'
+                       'Volumes/12345678-1234-5678-1234-567812345678/'
+                       'snap_count',
+                'value': None
+            },
+            {
+                'dir': False,
+                'name': 'snapd_inited',
+                'key': '/clusters/12345678-1234-5678-1234-567812345678/'
+                       'Volumes/12345678-1234-5678-1234-567812345678/'
+                       'snapd_inited',
+                'value': None
+            },
+            {
+                'dir': False,
+                'name': 'snapd_status',
+                'key': '/clusters/12345678-1234-5678-1234-567812345678/'
+                       'Volumes/12345678-1234-5678-1234-567812345678/'
+                       'snapd_status',
+                'value': None
+            },
+            {
+                'dir': False,
                 'name': 'status',
                 'key': '/clusters/12345678-1234-5678-1234-567812345678/'
                        'Volumes/12345678-1234-5678-1234-567812345678/'
                        'status',
-                'value': None},
+                'value': None
+            },
+            {
+                'dir': False,
+                'name': 'stripe_count',
+                'key': '/clusters/12345678-1234-5678-1234-567812345678/'
+                       'Volumes/12345678-1234-5678-1234-567812345678/'
+                       'stripe_count',
+                'value': None
+            },
+            {
+                'dir': False,
+                'name': 'subvol_count',
+                'key': '/clusters/12345678-1234-5678-1234-567812345678/'
+                       'Volumes/12345678-1234-5678-1234-567812345678/'
+                       'subvol_count',
+                'value': None
+            },
+            {
+                'dir': False,
+                'name': 'transport_type',
+                'key': '/clusters/12345678-1234-5678-1234-567812345678/'
+                       'Volumes/12345678-1234-5678-1234-567812345678/'
+                       'transport_type',
+                'value': None
+            },
             {
                 'dir': False,
                 'name': 'vol_id',
@@ -104,7 +249,8 @@ class Test_Volume(object):
                        'Volumes/12345678-1234-5678-1234-567812345678/'
                        'vol_type',
                 'value': None
-            }]
+            }
+        ]
 
 
 class Test_Brick(object):


### PR DESCRIPTION
As per new output from gluster get-state command, volume
option details are listed. Modiifed to parse and populate
the volume options details to the central store.

tendrl-bug-id: gluster_integration/#41
tendrl-spec: refactor_gluster_integration_get_state_dump.adoc

Signed-off-by: Shubhendu <shtripat@redhat.com>